### PR TITLE
Fix move assignment operator for callback list and unit test

### DIFF
--- a/include/eventpp/callbacklist.h
+++ b/include/eventpp/callbacklist.h
@@ -133,6 +133,12 @@ public:
 
 	CallbackListBase & operator = (CallbackListBase && other) noexcept {
 		if(this != &other) {
+			while(head) {
+				// Create copy because doFreeNode reset temp->counter
+				// after head reassignment.
+				auto temp = head;
+				doFreeNode(temp);
+			}
 			head = std::move(other.head);
 			tail = std::move(other.tail);
 			currentCounter = other.currentCounter.load();

--- a/tests/unittest/test_callbacklist_basic.cpp
+++ b/tests/unittest/test_callbacklist_basic.cpp
@@ -505,3 +505,15 @@ TEST_CASE("CallbackList, internal counter overflow")
 	}
 }
 
+TEST_CASE("CallbackList, move assignement")
+{
+	using CL = eventpp::CallbackList<void()>;
+	CL callbackList;
+	const auto h1 = callbackList.append([]() {});
+	const auto h2 = callbackList.append([]() {});
+	callbackList = {};
+
+	// Make sure nodes were destroyed
+	REQUIRE(h1.expired());
+	REQUIRE(h2.expired());
+}


### PR DESCRIPTION
The operator `CallbackListBase & operator = (CallbackListBase && other)` only release head and tail. 
* If there is one callback, then the node is destroyed. 
* If there is more, then they keep reference between each other and never get destroyed.

I fixed the problem on my fork in a branch [move-assignement-fix](https://github.com/OlivierLDff/eventpp/tree/move-assignment-fix)

Fix  in callbacklist.h
``` cpp
	CallbackListBase & operator = (CallbackListBase && other) noexcept {
		if(this != &other) {
			while(head) {
				// Create copy because doFreeNode reset temp->counter
				// after head reassignment.
				auto temp = head;
				doFreeNode(temp);
			}
			head = std::move(other.head);
			tail = std::move(other.tail);
			currentCounter = other.currentCounter.load();
		}
	}
```

And the unit test demonstrating the problem:
``` cpp
TEST_CASE("CallbackList, move assignement")
{
	using CL = eventpp::CallbackList<void()>;
	CL callbackList;
	const auto h1 = callbackList.append([]() {});
	const auto h2 = callbackList.append([]() {});
	callbackList = {};

	// Make sure nodes were destroyed
	REQUIRE(h1.expired());
	REQUIRE(h2.expired());
}
```