### PR TITLE
Enable or disable installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,56 +15,62 @@ add_library(eventpp::eventpp ALIAS eventpp)
 # Installation
 # ------------
 include(GNUInstallDirs)
+if (POLICY CMP0077)
+	cmake_policy(SET CMP0077 NEW)
+endif (POLICY CMP0077)
+option(EVENTPP_INSTALL "Enable installation (Projects embedding eventpp may want to turn this OFF)." ON)
 
-# Install the library
-install(
-	TARGETS eventpp
-	EXPORT eventppTargets
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+if (EVENTPP_INSTALL)
+	# Install the library
+	install(
+		TARGETS eventpp
+		EXPORT eventppTargets
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	)
 
-# Install the headers
-install(
-	DIRECTORY include/
-	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+	# Install the headers
+	install(
+		DIRECTORY include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	)
 
-# (Generate and) install the target import file
-install(
-	EXPORT eventppTargets
-	NAMESPACE eventpp::
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/eventpp
-)
+	# (Generate and) install the target import file
+	install(
+		EXPORT eventppTargets
+		NAMESPACE eventpp::
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/eventpp
+	)
 
-# Generate the package version file
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-	${CMAKE_CURRENT_BINARY_DIR}/eventppConfigVersion.cmake
-	VERSION ${PROJECT_VERSION}
-	COMPATIBILITY AnyNewerVersion
-)
+	# Generate the package version file
+	include(CMakePackageConfigHelpers)
+	write_basic_package_version_file(
+		${CMAKE_CURRENT_BINARY_DIR}/eventppConfigVersion.cmake
+		VERSION ${PROJECT_VERSION}
+		COMPATIBILITY AnyNewerVersion
+	)
 
-# Generate the package configuration file, that allows other
-# CMake projects to find the library with find_package()
-configure_package_config_file(
-	cmake/eventppConfig.cmake.in
-	${CMAKE_CURRENT_BINARY_DIR}/eventppConfig.cmake
-	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/eventpp
-)
+	# Generate the package configuration file, that allows other
+	# CMake projects to find the library with find_package()
+	configure_package_config_file(
+		cmake/eventppConfig.cmake.in
+		${CMAKE_CURRENT_BINARY_DIR}/eventppConfig.cmake
+		INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/eventpp
+	)
 
-# Install the package version and configuration files
-install(
-	FILES
-	${CMAKE_CURRENT_BINARY_DIR}/eventppConfig.cmake
-	${CMAKE_CURRENT_BINARY_DIR}/eventppConfigVersion.cmake
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/eventpp
-)
+	# Install the package version and configuration files
+	install(
+		FILES
+		${CMAKE_CURRENT_BINARY_DIR}/eventppConfig.cmake
+		${CMAKE_CURRENT_BINARY_DIR}/eventppConfigVersion.cmake
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/eventpp
+	)
 
-# Install readme and license
-install(
-	FILES
-	readme.md
-	license
-	DESTINATION ${CMAKE_INSTALL_DATADIR}/eventpp
-)
+	# Install readme and license
+	install(
+		FILES
+		readme.md
+		license
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/eventpp
+	)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,22 @@ target_include_directories(
 
 add_library(eventpp::eventpp ALIAS eventpp)
 
+# Checks if eventpp is the main project or if it is
+# being built as a subproject (using add_subdirectory/FetchContent).
+set(MAIN_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(MAIN_PROJECT ON)
+endif()
+
 # Installation
 # ------------
 include(GNUInstallDirs)
 if (POLICY CMP0077)
+	# Allow CMake 3.13+ to override options when using add_subdirectory/FetchContent.
 	cmake_policy(SET CMP0077 NEW)
 endif (POLICY CMP0077)
-option(EVENTPP_INSTALL "Enable installation (Projects embedding eventpp may want to turn this OFF)." ON)
+
+option(EVENTPP_INSTALL "Enable installation" ${MAIN_PROJECT})
 
 if (EVENTPP_INSTALL)
 	# Install the library


### PR DESCRIPTION
I added a CMake option that enables or disables the installation. The installation is automatically enabled when eventpp is the main project, and disabled when it is being fetched with `FetchContent` or `add_subdirectory()`. This behavior can be overridden by manually setting `EVENTPP_INSTALL`.

I needed this because I'm fetching eventpp in my own project, but when I try to install my stuff eventpp gets installed too and in this case I don't want this because it is already statically linked to my executable.