### PR TITLE
Remove use of CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 11)
 target_include_directories(
 	eventpp INTERFACE
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	$<INSTALL_INTERFACE:include>
 )
 
 add_library(eventpp::eventpp ALIAS eventpp)


### PR DESCRIPTION
This allows eventpp to be built with the hunter package manager.

It is not clear why this variable is not being set to `include` when using hunter. This allows eventpp to be used.

