### PR TITLE
Bump CMake minimum required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 project(eventpp VERSION 0.1.2)
 
 add_library(eventpp INTERFACE)


### PR DESCRIPTION
CMake 3.27 deprecates compatibility with versions older than 3.5 (see [here](https://cmake.org/cmake/help/latest/release/3.27.html#deprecated-and-removed-features)).
The following deprecation warning is issued:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

It's a minor inconvenience but I think we can safely drop support for CMake < 3.5 and hide the warning.